### PR TITLE
fix: The error `ActionController::InvalidAuthenticityToken` oc...

### DIFF
--- a/.activerabbit/fixes/issue-763-fix.md
+++ b/.activerabbit/fixes/issue-763-fix.md
@@ -1,0 +1,101 @@
+# Fix for ActionController::InvalidAuthenticityToken
+
+**Issue ID:** 763
+**Generated:** 2026-01-21 00:43 UTC
+**Status:** 📋 Suggestion only (manual review required)
+
+## Suggested Code Fix
+
+```ruby
+javascript
+$.ajax({
+  type: "POST",
+  url: "/your_endpoint",
+  data: yourData,
+  headers: {
+    'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+  }
+});
+```
+
+## Full Analysis
+
+## 🐛 Bug Fix: ActionController::InvalidAuthenticityToken
+
+**Issue ID:** #763
+**Controller:** `Devise::RegistrationsController#create`
+**Occurrences:** 68 times
+**First seen:** 2026-01-18 07:24
+**Last seen:** 2026-01-21 00:43
+
+## 🔍 Root Cause Analysis
+
+The error `ActionController::InvalidAuthenticityToken` occurs because the server is unable to verify the CSRF token included in the request. This typically happens when the CSRF token is missing, invalid, or not sent with the request, which is essential for security in Rails applications to prevent CSRF attacks.
+
+## 🔧 Suggested Fix
+
+Ensure that the CSRF token is correctly included in the form submission. If you are using Rails form helpers, they automatically include the CSRF token. If you are making an AJAX request, you need to manually include the CSRF token in the request headers.
+
+### Before
+If the form is missing the CSRF token:
+```erb
+<%= form_for @user do |f| %>
+  <!-- form fields -->
+<% end %>
+```
+
+### After
+Ensure the form includes the CSRF token:
+```erb
+<%= form_for @user, authenticity_token: true do |f| %>
+  <!-- form fields -->
+<% end %>
+```
+
+For AJAX requests, include the CSRF token in the headers:
+```javascript
+$.ajax({
+  type: "POST",
+  url: "/your_endpoint",
+  data: yourData,
+  headers: {
+    'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+  }
+});
+```
+
+## 📋 Error Details
+
+**Error Message:**
+```
+Can't verify CSRF token authenticity.
+```
+
+**Stack Trace (top frames):**
+```
+["/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/request_forgery_protection.rb:314:in `handle_unverified_request'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/request_forgery_protection.rb:408:in `handle_unverified_request'", "/usr/local/bundle/ruby/3.2.0/gems/devise-4.9.4/lib/devise/controllers/helpers.rb:257:in `handle_unverified_request'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/request_forgery_protection.rb:397:in `verify_authenticity_token'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:361:in `block in make_lambda'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:178:in `block in call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/abstract_controller/callbacks.rb:34:in `block (2 levels) in <module:Callbacks>'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:179:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in `block in invoke_before'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in `each'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in `invoke_before'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:118:in `block in run_callbacks'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:140:in `run_callbacks'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/abstract_controller/callbacks.rb:260:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/rescue.rb:27:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/instrumentation.rb:76:in `block in process_action'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/notifications.rb:210:in `block in instrument'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/notifications/instrumenter.rb:58:in `instrument'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/notifications.rb:210:in `instrument'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/instrumentation.rb:75:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/params_wrapper.rb:259:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/activerecord-8.0.2.1/lib/active_record/railties/controller_runtime.rb:39:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/abstract_controller/base.rb:163:in `process'", "/usr/local/bundle/ruby/3.2.0/gems/actionview-8.0.2.1/lib/action_view/rendering.rb:40:in `process'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal.rb:252:in `dispatch'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal.rb:335:in `dispatch'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:67:in `dispatch'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:50:in `serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/mapper.rb:32:in `block in <class:Constraints>'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/mapper.rb:62:in `serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:53:in `block in serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:133:in `block in find_routes'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:126:in `each'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:126:in `find_routes'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:34:in `serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:908:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:202:in `call!'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:169:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:202:in `call!'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:169:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-attack-6.7.0/lib/rack/attack.rb:103:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-attack-6.7.0/lib/rack/attack.rb:127:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/warden-1.2.9/lib/warden/manager.rb:36:in `block in call'", "/usr/local/bundle/ruby/3.2.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `catch'", "/usr/local/bundle/ruby/3.2.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/tempfile_reaper.rb:20:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/etag.rb:29:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/conditional_get.rb:44:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/head.rb:15:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/http/permissions_policy.rb:38:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/http/content_security_policy.rb:38:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:274:in `context'", "/usr/local/bundle/ruby/3.2.0/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:268:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/cookies.rb:706:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:100:in `run_callbacks'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/callbacks.rb:30:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/activerabbit-ai-0.5.2/lib/active_rabbit/middleware/error_capture_middleware.rb:11:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/railties-8.0.2.1/lib/rails/rack/logger.rb:41:in `call_app'", "/usr/local/bundle/ruby/3.2.0/gems/railties-8.0.2.1/lib/rails/rack/logger.rb:29:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/remote_ip.rb:96:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/request_id.rb:34:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/method_override.rb:28:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/runtime.rb:24:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/executor.rb:16:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/static.rb:27:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/sendfile.rb:114:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/railties-8.0.2.1/lib/rails/engine.rb:535:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/configuration.rb:279:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/request.rb:99:in `block in handle_request'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/thread_pool.rb:390:in `with_force_shutdown'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/request.rb:98:in `handle_request'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/server.rb:472:in `process_client'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/server.rb:254:in `block in run'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/thread_pool.rb:167:in `block in spawn_thread'"]
+```
+
+**Request Context:**
+- Method: `POST`
+- Path: `/`
+
+## 🛡️ Prevention
+
+- Always use Rails form helpers which automatically include the CSRF token.
+- For AJAX requests, ensure the CSRF token is included in the request headers.
+- Regularly update your Rails application to benefit from security improvements and patches.
+- Educate developers on the importance of CSRF protection and how to implement it correctly.
+
+## ✅ Checklist
+
+- [ ] Code fix implemented
+- [ ] Tests added/updated
+- [ ] Error scenario manually verified
+- [ ] No regressions introduced
+
+---
+_Generated by [ActiveRabbit](https://activerabbit.ai) AI_
+
+---
+_Generated by [ActiveRabbit](https://activerabbit.ai) AI_


### PR DESCRIPTION
## 🐛 Bug Fix: ActionController::InvalidAuthenticityToken

**Issue ID:** #763
**Controller:** `Devise::RegistrationsController#create`
**Occurrences:** 68 times
**First seen:** 2026-01-18 07:24
**Last seen:** 2026-01-21 00:43

## 🔍 Root Cause Analysis

The error `ActionController::InvalidAuthenticityToken` occurs because the server is unable to verify the CSRF token included in the request. This typically happens when the CSRF token is missing, invalid, or not sent with the request, which is essential for security in Rails applications to prevent CSRF attacks.

## 🔧 Suggested Fix

Ensure that the CSRF token is correctly included in the form submission. If you are using Rails form helpers, they automatically include the CSRF token. If you are making an AJAX request, you need to manually include the CSRF token in the request headers.

### Before
If the form is missing the CSRF token:
```erb
<%= form_for @user do |f| %>
  <!-- form fields -->
<% end %>
```

### After
Ensure the form includes the CSRF token:
```erb
<%= form_for @user, authenticity_token: true do |f| %>
  <!-- form fields -->
<% end %>
```

For AJAX requests, include the CSRF token in the headers:
```javascript
$.ajax({
  type: "POST",
  url: "/your_endpoint",
  data: yourData,
  headers: {
    'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
  }
});
```

## 📋 Error Details

**Error Message:**
```
Can't verify CSRF token authenticity.
```

**Stack Trace (top frames):**
```
["/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/request_forgery_protection.rb:314:in `handle_unverified_request'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/request_forgery_protection.rb:408:in `handle_unverified_request'", "/usr/local/bundle/ruby/3.2.0/gems/devise-4.9.4/lib/devise/controllers/helpers.rb:257:in `handle_unverified_request'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/request_forgery_protection.rb:397:in `verify_authenticity_token'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:361:in `block in make_lambda'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:178:in `block in call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/abstract_controller/callbacks.rb:34:in `block (2 levels) in <module:Callbacks>'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:179:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in `block in invoke_before'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in `each'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in `invoke_before'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:118:in `block in run_callbacks'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:140:in `run_callbacks'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/abstract_controller/callbacks.rb:260:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/rescue.rb:27:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/instrumentation.rb:76:in `block in process_action'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/notifications.rb:210:in `block in instrument'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/notifications/instrumenter.rb:58:in `instrument'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/notifications.rb:210:in `instrument'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/instrumentation.rb:75:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/params_wrapper.rb:259:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/activerecord-8.0.2.1/lib/active_record/railties/controller_runtime.rb:39:in `process_action'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/abstract_controller/base.rb:163:in `process'", "/usr/local/bundle/ruby/3.2.0/gems/actionview-8.0.2.1/lib/action_view/rendering.rb:40:in `process'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal.rb:252:in `dispatch'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_controller/metal.rb:335:in `dispatch'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:67:in `dispatch'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:50:in `serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/mapper.rb:32:in `block in <class:Constraints>'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/mapper.rb:62:in `serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:53:in `block in serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:133:in `block in find_routes'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:126:in `each'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:126:in `find_routes'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:34:in `serve'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:908:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:202:in `call!'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:169:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:202:in `call!'", "/usr/local/bundle/ruby/3.2.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:169:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-attack-6.7.0/lib/rack/attack.rb:103:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-attack-6.7.0/lib/rack/attack.rb:127:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/warden-1.2.9/lib/warden/manager.rb:36:in `block in call'", "/usr/local/bundle/ruby/3.2.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `catch'", "/usr/local/bundle/ruby/3.2.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/tempfile_reaper.rb:20:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/etag.rb:29:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/conditional_get.rb:44:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/head.rb:15:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/http/permissions_policy.rb:38:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/http/content_security_policy.rb:38:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:274:in `context'", "/usr/local/bundle/ruby/3.2.0/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:268:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/cookies.rb:706:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'", "/usr/local/bundle/ruby/3.2.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:100:in `run_callbacks'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/callbacks.rb:30:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/activerabbit-ai-0.5.2/lib/active_rabbit/middleware/error_capture_middleware.rb:11:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/railties-8.0.2.1/lib/rails/rack/logger.rb:41:in `call_app'", "/usr/local/bundle/ruby/3.2.0/gems/railties-8.0.2.1/lib/rails/rack/logger.rb:29:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/remote_ip.rb:96:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/request_id.rb:34:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/method_override.rb:28:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/runtime.rb:24:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/executor.rb:16:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/static.rb:27:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/rack-3.2.0/lib/rack/sendfile.rb:114:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/railties-8.0.2.1/lib/rails/engine.rb:535:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/configuration.rb:279:in `call'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/request.rb:99:in `block in handle_request'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/thread_pool.rb:390:in `with_force_shutdown'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/request.rb:98:in `handle_request'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/server.rb:472:in `process_client'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/server.rb:254:in `block in run'", "/usr/local/bundle/ruby/3.2.0/gems/puma-6.6.1/lib/puma/thread_pool.rb:167:in `block in spawn_thread'"]
```

**Request Context:**
- Method: `POST`
- Path: `/`

## 🛡️ Prevention

- Always use Rails form helpers which automatically include the CSRF token.
- For AJAX requests, ensure the CSRF token is included in the request headers.
- Regularly update your Rails application to benefit from security improvements and patches.
- Educate developers on the importance of CSRF protection and how to implement it correctly.

## ✅ Checklist

- [ ] Code fix implemented
- [ ] Tests added/updated
- [ ] Error scenario manually verified
- [ ] No regressions introduced

---
_Generated by [ActiveRabbit](https://activerabbit.ai) AI_