### PR TITLE
fix: The error occurs because the `default_project_path_for` m...

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,13 +71,15 @@ class ApplicationController < ActionController::Base
   end
 
   def default_project_path_for(resource)
-    projects = ActsAsTenant.without_tenant { resource.account&.projects }
+    ActsAsTenant.without_tenant do
+    projects = resource.account&.projects
     last_slug = cookies[:last_project_slug]
     project = projects&.find_by(slug: last_slug) if last_slug.present?
     project ||= projects&.order(:name)&.first
-    project ? project_slug_errors_path(project.slug) : dashboard_path
+  project ? project_slug_errors_path(project.slug) : dashboard_path
   end
 
+  end
   def current_project
     @current_project
   end


### PR DESCRIPTION
## 🐛 Bug Fix: ActsAsTenant::Errors::NoTenantSet

**Issue ID:** [#2064](app.activerabbit.ai/activerabbit/errors/2064)
**Controller:** `Devise::PasswordsController#edit`
**Occurrences:** 2 times
**First seen:** 2026-03-17 17:17
**Last seen:** 2026-03-17 17:17

## 🔍 Root Cause Analysis

The error occurs because the `default_project_path_for` method is trying to access `projects` on line 76 without a tenant being set. This happens during the Devise password reset flow, where the tenant setup is skipped for Devise controllers, but the `after_sign_in_path_for` method still gets called and tries to access tenant-scoped data.

## 🔧 Suggested Fix

### File 1: `app/controllers/application_controller.rb`
**Line:** 73-78

**Before:**

```ruby
  def default_project_path_for(resource)
    projects = ActsAsTenant.without_tenant { resource.account&.projects }
    last_slug = cookies[:last_project_slug]
    project = projects&.find_by(slug: last_slug) if last_slug.present?
    project ||= projects&.order(:name)&.first
    project ? project_slug_errors_path(project.slug) : dashboard_path
  end
```

**After:**

```ruby
  def default_project_path_for(resource)
    ActsAsTenant.without_tenant do
      projects = resource.account&.projects
      last_slug = cookies[:last_project_slug]
      project = projects&.find_by(slug: last_slug) if last_slug.present?
      project ||= projects&.order(:name)&.first
      project ? project_slug_errors_path(project.slug) : dashboard_path
    end
  end
```

## 📋 Error Details

**Error Message:**
```
ActsAsTenant::Errors::NoTenantSet
```

**Stack Trace (top frames):**
```
["/usr/local/bundle/ruby/3.4.0/gems/acts_as_tenant-1.0.1/lib/acts_as_tenant/model_extensions.rb:21:in 'block in ActsAsTenant::ModelExtensions::ClassMethods#acts_as_tenant'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:163:in 'BasicObject#instance_exec'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:163:in 'block (2 levels) in ActiveRecord::Scoping::Default::ClassMethods#build_default_scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:159:in 'Array#each'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:159:in 'Enumerable#inject'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:159:in 'block in ActiveRecord::Scoping::Default::ClassMethods#build_default_scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:197:in 'ActiveRecord::Scoping::Default::ClassMethods#evaluate_default_scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/default.rb:158:in 'ActiveRecord::Scoping::Default::ClassMethods#build_default_scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/named.rb:46:in 'ActiveRecord::Scoping::Named::ClassMethods#default_scoped'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/scoping/named.rb:40:in 'ActiveRecord::Scoping::Named::ClassMethods#scope_for_association'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/associations/association.rb:313:in 'ActiveRecord::Associations::Association#target_scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/associations/association.rb:115:in 'ActiveRecord::Associations::Association#scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/associations/collection_association.rb:299:in 'ActiveRecord::Associations::CollectionAssociation#scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/associations/collection_proxy.rb:950:in 'ActiveRecord::Associations::CollectionProxy#scope'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/associations/collection_proxy.rb:1137:in 'ActiveRecord::Associations::CollectionProxy#where'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/relation/finder_methods.rb:112:in 'ActiveRecord::FinderMethods#find_by'", "/rails/app/controllers/application_controller.rb:76:in 'ApplicationController#default_project_path_for'", "/rails/app/controllers/application_controller.rb:66:in 'ApplicationController#after_sign_in_path_for'", "/usr/local/bundle/ruby/3.4.0/gems/devise-4.9.4/app/controllers/devise_controller.rb:130:in 'DeviseController#require_no_authentication'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:361:in 'block in ActiveSupport::Callbacks::CallTemplate::MethodCall#make_lambda'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:178:in 'block in ActiveSupport::Callbacks::Filters::Before#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/abstract_controller/callbacks.rb:34:in 'block (2 levels) in <module:Callbacks>'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:179:in 'ActiveSupport::Callbacks::Filters::Before#call'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in 'block in ActiveSupport::Callbacks::CallbackSequence#invoke_before'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in 'Array#each'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:559:in 'ActiveSupport::Callbacks::CallbackSequence#invoke_before'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:118:in 'block in ActiveSupport::Callbacks#run_callbacks'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/abstract_controller/callbacks.rb:260:in 'AbstractController::Callbacks#process_action'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/rescue.rb:27:in 'ActionController::Rescue#process_action'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/instrumentation.rb:76:in 'block in ActionController::Instrumentation#process_action'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/instrumentation.rb:75:in 'ActionController::Instrumentation#process_action'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_controller/metal/params_wrapper.rb:259:in 'ActionController::ParamsWrapper#process_action'", "/usr/local/bundle/ruby/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/railties/controller_runtime.rb:39:in 'ActiveRecord::Railties::ControllerRuntime#process_action'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/abstract_controller/base.rb:163:in 'AbstractController::Base#process'", "/usr/local/bundle/ruby/3.4.0/gems/actionview-8.0.2.1/lib/action_view/rendering.rb:40:in 'ActionView::Rendering#process'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_controller/metal.rb:252:in 'ActionController::Metal#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_controller/metal.rb:335:in 'ActionController::Metal.dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:67:in 'ActionDispatch::Routing::RouteSet::Dispatcher#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:50:in 'ActionDispatch::Routing::RouteSet::Dispatcher#serve'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/mapper.rb:32:in 'block in <class:Constraints>'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/mapper.rb:62:in 'ActionDispatch::Routing::Mapper::Constraints#serve'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:53:in 'block in ActionDispatch::Journey::Router#serve'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:133:in 'block in ActionDispatch::Journey::Router#find_routes'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:126:in 'Array#each'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:126:in 'ActionDispatch::Journey::Router#find_routes'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/journey/router.rb:34:in 'ActionDispatch::Journey::Router#serve'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/routing/route_set.rb:908:in 'ActionDispatch::Routing::RouteSet#call'", "/usr/local/bundle/ruby/3.4.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:202:in 'OmniAuth::Strategy#call!'", "/usr/local/bundle/ruby/3.4.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:169:in 'OmniAuth::Strategy#call'", "/usr/local/bundle/ruby/3.4.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:202:in 'OmniAuth::Strategy#call!'", "/usr/local/bundle/ruby/3.4.0/gems/omniauth-2.1.4/lib/omniauth/strategy.rb:169:in 'OmniAuth::Strategy#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-attack-6.7.0/lib/rack/attack.rb:103:in 'Rack::Attack#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-attack-6.7.0/lib/rack/attack.rb:127:in 'Rack::Attack#call'", "/usr/local/bundle/ruby/3.4.0/gems/warden-1.2.9/lib/warden/manager.rb:36:in 'block in Warden::Manager#call'", "/usr/local/bundle/ruby/3.4.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in 'Kernel#catch'", "/usr/local/bundle/ruby/3.4.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in 'Warden::Manager#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/tempfile_reaper.rb:20:in 'Rack::TempfileReaper#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/etag.rb:29:in 'Rack::ETag#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/conditional_get.rb:31:in 'Rack::ConditionalGet#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/head.rb:15:in 'Rack::Head#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/http/permissions_policy.rb:38:in 'ActionDispatch::PermissionsPolicy::Middleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/http/content_security_policy.rb:38:in 'ActionDispatch::ContentSecurityPolicy::Middleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:274:in 'Rack::Session::Abstract::Persisted#context'", "/usr/local/bundle/ruby/3.4.0/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:268:in 'Rack::Session::Abstract::Persisted#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/cookies.rb:706:in 'ActionDispatch::Cookies#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/callbacks.rb:31:in 'block in ActionDispatch::Callbacks#call'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/callbacks.rb:100:in 'ActiveSupport::Callbacks#run_callbacks'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/callbacks.rb:30:in 'ActionDispatch::Callbacks#call'", "/usr/local/bundle/ruby/3.4.0/gems/activerabbit-ai-0.6.2/lib/active_rabbit/middleware/error_capture_middleware.rb:11:in 'ActiveRabbit::Middleware::ErrorCaptureMiddleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/debug_exceptions.rb:31:in 'ActionDispatch::DebugExceptions#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/show_exceptions.rb:32:in 'ActionDispatch::ShowExceptions#call'", "/usr/local/bundle/ruby/3.4.0/gems/railties-8.0.2.1/lib/rails/rack/logger.rb:41:in 'Rails::Rack::Logger#call_app'", "/usr/local/bundle/ruby/3.4.0/gems/railties-8.0.2.1/lib/rails/rack/logger.rb:29:in 'Rails::Rack::Logger#call'", "/usr/local/bundle/ruby/3.4.0/gems/railties-8.0.2.1/lib/rails/rack/silence_request.rb:28:in 'Rails::Rack::SilenceRequest#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/remote_ip.rb:96:in 'ActionDispatch::RemoteIp#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/request_id.rb:34:in 'ActionDispatch::RequestId#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/method_override.rb:28:in 'Rack::MethodOverride#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/runtime.rb:24:in 'Rack::Runtime#call'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in 'ActiveSupport::Cache::Strategy::LocalCache::Middleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/executor.rb:16:in 'ActionDispatch::Executor#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/static.rb:27:in 'ActionDispatch::Static#call'", "/usr/local/bundle/ruby/3.4.0/gems/rack-3.2.0/lib/rack/sendfile.rb:114:in 'Rack::Sendfile#call'", "/usr/local/bundle/ruby/3.4.0/gems/actionpack-8.0.2.1/lib/action_dispatch/middleware/assume_ssl.rb:24:in 'ActionDispatch::AssumeSSL#call'", "/usr/local/bundle/ruby/3.4.0/gems/railties-8.0.2.1/lib/rails/engine.rb:535:in 'Rails::Engine#call'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/configuration.rb:279:in 'Puma::Configuration::ConfigMiddleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/request.rb:99:in 'block in Puma::Request#handle_request'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/thread_pool.rb:390:in 'Puma::ThreadPool#with_force_shutdown'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/request.rb:98:in 'Puma::Request#handle_request'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/server.rb:472:in 'Puma::Server#process_client'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/server.rb:254:in 'block in Puma::Server#run'", "/usr/local/bundle/ruby/3.4.0/gems/puma-6.6.1/lib/puma/thread_pool.rb:167:in 'block in Puma::ThreadPool#spawn_thread'"]
```

**Request Context:**
- Method: `GET`
- Path: `/password/edit?reset_password_token=FgHosXRFb4JjytuEzeBa`

## 🛡️ Prevention

- Always wrap tenant-scoped model access in `ActsAsTenant.without_tenant` blocks when called from contexts where the tenant might not be set (like Devise controllers)
- Consider adding a helper method for safe tenant-scoped queries that automatically handles the `NoTenantSet` error

## ✅ Checklist

- [ ] Code fix implemented
- [ ] Tests added/updated
- [ ] Error scenario manually verified
- [ ] No regressions introduced

---
_Generated by [ActiveRabbit](https://activerabbit.ai) AI_