### PR TITLE
fix: The job is trying to write to a read-only Redis replica

### DIFF
--- a/app/jobs/error_batch_ingest_job.rb
+++ b/app/jobs/error_batch_ingest_job.rb
@@ -14,11 +14,14 @@ class ErrorBatchIngestJob
     # skip it if the batch was already processed.
     if batch_id.present?
       dedup_key = "batch_ingest_dedup:#{project_id}:#{batch_id}"
-      already_processed = Sidekiq.redis { |c| c.set(dedup_key, "1", nx: true, ex: DEDUP_TTL) }
-      unless already_processed
-        Rails.logger.info "[ErrorBatchIngest] Duplicate batch skipped: #{batch_id}"
-        return
+      already_processed = Sidekiq.redis(&:ping) rescue false
+      if already_processed
+        already_processed = Sidekiq.redis { |c| c.set(dedup_key, "1", nx: true, ex: DEDUP_TTL) } rescue false
       end
+        return
+      unless already_processed
+      end
+      Rails.logger.warn "[ErrorBatchIngest] Redis write failed, processing batch anyway: #{batch_id}"
     end
 
     project = ActsAsTenant.without_tenant { Project.find(project_id) }


### PR DESCRIPTION
## 🐛 Bug Fix: RedisClient::ReadOnlyError

**Issue ID:** [#1420](app.activerabbit.ai/activerabbit/errors/1420)
**Controller:** `unknown`
**Occurrences:** 2 times
**First seen:** 2026-02-14 07:32
**Last seen:** 2026-03-16 06:54

## 🔍 Root Cause Analysis

The job is trying to write to a read-only Redis replica. Redis is configured in a primary-replica setup, and the Sidekiq connection is pointing to a read-only replica that cannot accept write commands like `SET`.

## 🔧 Suggested Fix

### File 1: `app/jobs/error_batch_ingest_job.rb`
**Line:** 17

**Before:**

```ruby
          already_processed = Sidekiq.redis { |c| c.set(dedup_key, "1", nx: true, ex: DEDUP_TTL) }
          unless already_processed
            Rails.logger.info "[ErrorBatchIngest] Duplicate batch skipped: #{batch_id}"
```

**After:**

```ruby
          already_processed = Sidekiq.redis(&:ping) rescue false
          if already_processed
            already_processed = Sidekiq.redis { |c| c.set(dedup_key, "1", nx: true, ex: DEDUP_TTL) } rescue false
          end
          unless already_processed
            Rails.logger.warn "[ErrorBatchIngest] Redis write failed, processing batch anyway: #{batch_id}"
```

## ⚠️ Related Changes (Manual Review Required)

> **Note:** This PR only fixes the primary error file. The following additional changes may be needed and should be applied locally before merging:

The proper fix requires updating the Redis configuration to point to the primary instance:

- **config/initializers/sidekiq.rb**: Update the Redis URL to point to the primary/master Redis instance instead of the read-only replica
- **config/redis.yml** or **config/database.yml**: Ensure Redis write operations use the primary Redis URL (typically on a different port or hostname than replicas)

## 📋 Error Details

**Error Message:**
```
READONLY You can't write against a read only replica. (redis://activerabbit-redis:6379)
```

**Stack Trace (top frames):**
```
["/usr/local/bundle/ruby/3.4.0/gems/redis-client-0.25.2/lib/redis_client/connection_mixin.rb:36:in 'RedisClient::ConnectionMixin#call'", "/usr/local/bundle/ruby/3.4.0/gems/redis-client-0.25.2/lib/redis_client.rb:301:in 'block (2 levels) in RedisClient#call'", "/usr/local/bundle/ruby/3.4.0/gems/redis-client-0.25.2/lib/redis_client/middlewares.rb:16:in 'RedisClient::BasicMiddleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/redis-client-0.25.2/lib/redis_client.rb:300:in 'block in RedisClient#call'", "/usr/local/bundle/ruby/3.4.0/gems/redis-client-0.25.2/lib/redis_client.rb:721:in 'RedisClient#ensure_connected'", "/usr/local/bundle/ruby/3.4.0/gems/redis-client-0.25.2/lib/redis_client.rb:299:in 'RedisClient#call'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/redis_client_adapter.rb:35:in 'block (2 levels) in <module:CompatMethods>'", "/rails/app/jobs/error_batch_ingest_job.rb:17:in 'block in ErrorBatchIngestJob#perform'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/capsule.rb:107:in 'block in Sidekiq::Capsule#redis'", "/usr/local/bundle/ruby/3.4.0/gems/connection_pool-2.5.3/lib/connection_pool.rb:110:in 'block (2 levels) in ConnectionPool#with'", "/usr/local/bundle/ruby/3.4.0/gems/connection_pool-2.5.3/lib/connection_pool.rb:109:in 'Thread.handle_interrupt'", "/usr/local/bundle/ruby/3.4.0/gems/connection_pool-2.5.3/lib/connection_pool.rb:109:in 'block in ConnectionPool#with'", "/usr/local/bundle/ruby/3.4.0/gems/connection_pool-2.5.3/lib/connection_pool.rb:106:in 'Thread.handle_interrupt'", "/usr/local/bundle/ruby/3.4.0/gems/connection_pool-2.5.3/lib/connection_pool.rb:106:in 'ConnectionPool#with'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/capsule.rb:104:in 'Sidekiq::Capsule#redis'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq.rb:74:in 'Sidekiq.redis'", "/rails/app/jobs/error_batch_ingest_job.rb:17:in 'ErrorBatchIngestJob#perform'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:227:in 'Sidekiq::Processor#execute_job'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:192:in 'block (4 levels) in Sidekiq::Processor#process'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:180:in 'Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:183:in 'block in Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/activerabbit-ai-0.6.2/lib/active_rabbit/client/sidekiq_middleware.rb:14:in 'ActiveRabbit::Client::SidekiqMiddleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:182:in 'Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:183:in 'block in Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/job/interrupt_handler.rb:9:in 'Sidekiq::Job::InterruptHandler#call'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:182:in 'Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:183:in 'block in Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/metrics/tracking.rb:26:in 'Sidekiq::Metrics::ExecutionTracker#track'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/metrics/tracking.rb:136:in 'Sidekiq::Metrics::Middleware#call'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:182:in 'Sidekiq::Middleware::Chain#traverse'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/middleware/chain.rb:173:in 'Sidekiq::Middleware::Chain#invoke'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:191:in 'block (3 levels) in Sidekiq::Processor#process'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:151:in 'block (7 levels) in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/job_retry.rb:118:in 'Sidekiq::JobRetry#local'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:150:in 'block (6 levels) in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/rails.rb:19:in 'block in Sidekiq::Rails::Reloader#call'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/reloader.rb:77:in 'block in ActiveSupport::Reloader.wrap'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/execution_wrapper.rb:91:in 'ActiveSupport::ExecutionWrapper.wrap'", "/usr/local/bundle/ruby/3.4.0/gems/activesupport-8.0.2.1/lib/active_support/reloader.rb:74:in 'ActiveSupport::Reloader.wrap'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/rails.rb:18:in 'Sidekiq::Rails::Reloader#call'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:145:in 'block (5 levels) in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:123:in 'Sidekiq::Processor#profile'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:140:in 'block (4 levels) in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:288:in 'Sidekiq::Processor#stats'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:139:in 'block (3 levels) in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/job_logger.rb:15:in 'Sidekiq::JobLogger#call'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:138:in 'block (2 levels) in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/job_retry.rb:85:in 'Sidekiq::JobRetry#global'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:137:in 'block in Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/job_logger.rb:40:in 'Sidekiq::JobLogger#prepare'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:136:in 'Sidekiq::Processor#dispatch'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:190:in 'block (2 levels) in Sidekiq::Processor#process'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:189:in 'Thread.handle_interrupt'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:189:in 'block in Sidekiq::Processor#process'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:188:in 'Thread.handle_interrupt'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:188:in 'Sidekiq::Processor#process'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:87:in 'Sidekiq::Processor#process_one'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/processor.rb:77:in 'Sidekiq::Processor#run'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/component.rb:37:in 'Sidekiq::Component#watchdog'", "/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.7/lib/sidekiq/component.rb:46:in 'block in Sidekiq::Component#safe_thread'"]
```

**Request Context:**
- Method: `N/A`
- Path: `N/A`

## 🛡️ Prevention

- Configure separate Redis connections for read and write operations when using Redis replication
- Monitor Redis connection URLs in production to ensure write operations always target the primary instance

## ✅ Checklist

- [ ] Code fix implemented
- [ ] Tests added/updated
- [ ] Error scenario manually verified
- [ ] No regressions introduced

---
_Generated by [ActiveRabbit](https://activerabbit.ai) AI_